### PR TITLE
Updated sensor.py - fixed deprecated constant

### DIFF
--- a/custom_components/hydro_imgw/manifest.json
+++ b/custom_components/hydro_imgw/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": [],
   "codeowners": ["@PiotrMachowski"],
   "requirements": ["requests"],
-  "version": "v1.0.4",
+  "version": "v1.0.5",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/hydro_imgw/sensor.py
+++ b/custom_components/hydro_imgw/sensor.py
@@ -5,7 +5,7 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import (PLATFORM_SCHEMA, ENTITY_ID_FORMAT)
-from homeassistant.const import CONF_NAME, LENGTH_CENTIMETERS
+from homeassistant.const import CONF_NAME, UnitOfLength
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity import async_generate_entity_id
 
@@ -74,7 +74,7 @@ class HydroImgwSensor(Entity):
 
     @property
     def unit_of_measurement(self):
-        return LENGTH_CENTIMETERS
+        return UnitOfLength.CENTIMETERS
 
     def update(self):
         address = 'https://hydro.imgw.pl/api/station/hydro/?id={}'.format(self._station_id)


### PR DESCRIPTION
fixed deprecated constant - LENGTH_CENTIMETERS was used from hydro_imgw, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfLength.CENTIMETERS instead